### PR TITLE
Change conversion of score to float

### DIFF
--- a/collectors/htcondor/src/auditor_htcondor_collector/collector.py
+++ b/collectors/htcondor/src/auditor_htcondor_collector/collector.py
@@ -205,7 +205,7 @@ class CondorHistoryCollector(object):
                 comp = Component(name=component["name"], amount=amount)
                 for score in component.get("scores", []):
                     value = get_value(score, job) or "0.0"
-                    comp.with_score(Score(score["name"], maybe_convert(value)))
+                    comp.with_score(Score(score["name"], float(value)))
                 components.append(comp)
             else:
                 self.logger.warning(


### PR DESCRIPTION
Currently, the HTCondor collector converts the score string into integer with the [maybe_convert](https://github.com/ALU-Schumacher/AUDITOR/blame/e3c429294ea0ef609cf8e27040ada1670e29a7d1/collectors/htcondor/src/auditor_htcondor_collector/utils.py#L32) function. Therefore, the scores of the stored in the Database are wrong.

This should fix the issue https://github.com/ALU-Schumacher/AUDITOR/issues/989